### PR TITLE
build(deps): update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayvec"
@@ -127,9 +127,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -157,18 +157,18 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -178,9 +178,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]
@@ -193,22 +193,22 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.47"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+checksum = "c91d3baa3bcd889d60e6ef28874126a0b384fd225ab83aa6d8a801c519194ce1"
 dependencies = [
  "clap",
 ]
@@ -282,7 +282,7 @@ dependencies = [
  "derive-new",
  "havok_types",
  "havok_types_derive",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "jwalk",
  "num-derive",
  "num-traits",
@@ -362,18 +362,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -390,24 +390,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -508,9 +508,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "educe"
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "float-cmp"
@@ -603,9 +603,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -627,7 +627,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -639,9 +639,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -670,7 +670,7 @@ version = "0.8.2"
 dependencies = [
  "arrayvec",
  "havok_types",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "static_assertions",
- "winnow 0.6.26",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -749,14 +749,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -795,12 +796,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "rayon",
  "serde",
 ]
@@ -837,9 +838,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -942,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libyml"
@@ -958,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -976,9 +977,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1046,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "overload"
@@ -1083,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "portable-atomic"
@@ -1111,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1131,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1199,18 +1200,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1260,9 +1261,9 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schemars"
@@ -1271,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ef2a6523400a2228db974a8ddc9e1d3deaa04f51bddd7832ef8d7e531bafcc"
 dependencies = [
  "dyn-clone",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -1333,7 +1334,7 @@ dependencies = [
  "havok_serde",
  "havok_types",
  "html-escape",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "num-derive",
  "num-traits",
  "pretty_assertions",
@@ -1342,7 +1343,7 @@ dependencies = [
  "snafu",
  "static_assertions",
  "tracing",
- "winnow 0.6.26",
+ "winnow 0.7.10",
  "zerocopy",
 ]
 
@@ -1356,7 +1357,7 @@ dependencies = [
  "havok_classes",
  "havok_serde",
  "havok_types",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "jwalk",
  "parse-display",
  "quick_tracing",
@@ -1394,7 +1395,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1420,7 +1421,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "libyml",
  "memchr",
@@ -1446,9 +1447,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-json"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
+checksum = "c962f626b54771990066e5435ec8331d1462576cd2d1e62f24076ae014f92112"
 dependencies = [
  "getrandom",
  "halfbrown",
@@ -1473,9 +1474,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snafu"
@@ -1541,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1582,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1597,15 +1598,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1613,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1644,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
@@ -1654,7 +1655,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -1730,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -1754,9 +1755,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
@@ -1877,11 +1878,61 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1968,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -2001,18 +2052,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,16 @@ resolver = "2"
 
 [workspace.dependencies]
 bitflags = "2.9.0"                                             # To generate flags type
-clap = { version = "4.5.34", features = ["derive"] }           # For CLI
+clap = { version = "4.5.38", features = ["derive"] }           # For CLI
 color-print = "0.3.7"                                          # To color example help
 educe = "0.6.0"                                                # Custom derive by derive
-indexmap = "2.8.0"                                             # Ordering HashMap
+indexmap = "2.9.0"                                             # Ordering HashMap
 jwalk = { version = "0.8.1" }                                  # To enumerate json class files
 num-derive = "0.4"                                             # To serialize Enum & Flags
 num-traits = "0.2.19"                                          # To serialize Enum & Flags
 parse-display = "0.10.0"                                       # Display derive
 lexical = { version = "7.0.4", features = ["radix", "format", "power-of-two"] }
-proc-macro2 = { version = "1.0.94", default-features = false } # Rust token
+proc-macro2 = { version = "1.0.95", default-features = false } # Rust token
 quote = { version = "1.0.40", default-features = false }       # Rust token gen to more convenience
 rayon = { version = "1.10.0" }                                 # Parallel
 schemars = { version = "1.0.0-alpha.17" }
@@ -47,10 +47,10 @@ serde_with = "3.12.0"                                          # Serde utility
 similar = "2.7.0"                                              # Create diff
 snafu = "0.8.5"                                                # Define all error patterns(with backtrace)
 static_assertions = "1.1.0"                                    # Compile tim assertions
-syn = { version = "2.0.100", default-features = false }         # Rust parser
-tokio = { version = "1.44.1" }                                 # Async runtime
+syn = { version = "2.0.101", default-features = false }         # Rust parser
+tokio = { version = "1.45.0" }                                 # Async runtime
 tracing = { version = "0.1.41" }                               # logger
-winnow = { version = "0.6.26", features = ["simd"] } # Parser combinator
+winnow = { version = "0.7.10", features = ["simd"] } # Parser combinator
 
 # workspace members
 havok_classes = { path = "./crates/havok_classes" }

--- a/crates/class_generator/Cargo.toml
+++ b/crates/class_generator/Cargo.toml
@@ -26,7 +26,7 @@ serde_with = { workspace = true }                     # Serde utility
 snafu = { workspace = true }                          # Define all error patterns(with backtrace)
 tracing = { workspace = true }                        # Logger
 
-prettyplease = "0.2.25"
+prettyplease = "0.2.32"
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = [

--- a/crates/serde_hkx_features/Cargo.toml
+++ b/crates/serde_hkx_features/Cargo.toml
@@ -31,7 +31,7 @@ basic-toml = { version = "0.1.10", optional = true }
 schemars = { workspace = true, features = ["indexmap2"], optional = true }
 serde = { workspace = true, optional = true }
 serde_yml = { version = "0.0.12", optional = true }
-simd-json = { version = "0.15.0", optional = true }
+simd-json = { version = "0.15.1", optional = true }
 
 # workspace members
 havok_serde = { workspace = true }

--- a/serde_hkx/src/bytes/de/mod.rs
+++ b/serde_hkx/src/bytes/de/mod.rs
@@ -28,7 +28,7 @@ use crate::errors::{
 use havok_serde::de::{self, Deserialize, ReadEnumSize, Visitor};
 use havok_types::*;
 use winnow::binary::Endianness;
-use winnow::error::{StrContext, StrContextValue};
+use winnow::error::{ContextError, ErrMode, StrContext, StrContextValue};
 use winnow::{Parser, binary};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -195,7 +195,7 @@ impl<'de> BytesDeserializer<'de> {
     /// If an error occurs, it is converted to [`ReadableError`] and returned.
     fn parse_peek<O, P>(&self, mut parser: P) -> Result<O>
     where
-        P: Parser<BytesStream<'de>, O, winnow::error::ContextError>,
+        P: Parser<BytesStream<'de>, O, winnow::error::ErrMode<ContextError>>,
     {
         let (_, res) = parser
             .parse_peek(&self.input[self.current_position..])
@@ -208,7 +208,7 @@ impl<'de> BytesDeserializer<'de> {
     /// If an error occurs, it is converted to [`Error::ContextError`] and returned.
     fn parse_range<O, P>(&self, mut parser: P, range: Range<usize>) -> Result<O>
     where
-        P: Parser<BytesStream<'de>, O, winnow::error::ContextError>,
+        P: Parser<BytesStream<'de>, O, ErrMode<ContextError>>,
     {
         let (_, res) = parser
             .parse_peek(&self.input[range])
@@ -351,7 +351,7 @@ impl<'de> BytesDeserializer<'de> {
     /// Jump current position(`local_fixup.src`) to dst, then parse, and back to current position.
     fn parse_local_fixup<O, P>(&mut self, parser: P) -> Result<Option<O>>
     where
-        P: Parser<BytesStream<'de>, O, winnow::error::ContextError>,
+        P: Parser<BytesStream<'de>, O, winnow::error::ErrMode<ContextError>>,
     {
         let backup_position = self.current_position();
         self.current_position = match self.get_local_fixup_dst().ok() {

--- a/serde_hkx/src/bytes/de/parser/fixups.rs
+++ b/serde_hkx/src/bytes/de/parser/fixups.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use winnow::{
     Parser,
     binary::{self, Endianness},
-    error::{ContextError, StrContext, StrContextValue::*},
+    error::{ContextError, ErrMode, StrContext, StrContextValue::*},
     token::take_while,
 };
 
@@ -82,7 +82,7 @@ impl Fixups {
     pub fn from_section_header<'a>(
         header: &SectionHeader,
         endian: Endianness,
-    ) -> impl Parser<&'a [u8], Self, ContextError> {
+    ) -> impl Parser<&'a [u8], Self, ErrMode<ContextError>> {
         let SectionHeader {
             local_fixups_offset,
             global_fixups_offset,
@@ -128,7 +128,7 @@ fn read_local_fixups(
 ) -> winnow::ModalResult<LocalFixups> {
     let mut local_map = LocalFixups::new();
     for _ in 0..len {
-        if let Ok(local_src) = binary::u32::<&[u8], ContextError>(endian)
+        if let Ok(local_src) = binary::u32::<&[u8], ErrMode<ContextError>>(endian)
             .verify(|&src| src != FIXUP_VALUE_FOR_ALIGN)
             .context(StrContext::Expected(Description("local_fixup.src(u32)")))
             .parse_next(bytes)
@@ -163,7 +163,7 @@ fn read_fixups(
 ) -> winnow::ModalResult<VirtualFixups> {
     let mut fixups = VirtualFixups::new();
     for _ in 0..len {
-        if let Ok(src) = binary::u32::<&[u8], ContextError>(endian)
+        if let Ok(src) = binary::u32::<&[u8], ErrMode<ContextError>>(endian)
             .verify(|src| *src != FIXUP_VALUE_FOR_ALIGN)
             .parse_next(bytes)
         {

--- a/serde_hkx/src/bytes/serde/hkx_header.rs
+++ b/serde_hkx/src/bytes/serde/hkx_header.rs
@@ -45,7 +45,7 @@ use winnow::{
     Parser,
     binary::{self, Endianness},
     combinator::{dispatch, empty, fail},
-    error::{ContextError, StrContext, StrContextValue::*},
+    error::{ContextError, ErrMode, StrContext, StrContextValue::*},
     seq,
     token::{take, take_until},
 };
@@ -137,7 +137,7 @@ impl HkxHeader {
     }
 
     /// Check valid endian & Parse as hkx root header.
-    pub fn parser<'a>() -> impl Parser<&'a [u8], Self, ContextError> {
+    pub fn parser<'a>() -> impl Parser<&'a [u8], Self, ErrMode<ContextError>> {
         move |bytes: &mut &[u8]| {
             let endianness = {
                 let (mut bytes, _) = take(17_usize).parse_peek(*bytes)?;

--- a/serde_hkx/src/bytes/serde/section_header.rs
+++ b/serde_hkx/src/bytes/serde/section_header.rs
@@ -8,7 +8,7 @@ use std::io;
 use winnow::{
     Parser,
     binary::{self, Endianness},
-    error::{ContextError, StrContext, StrContextValue::*},
+    error::{ContextError, ErrMode, StrContext, StrContextValue::*},
     seq,
     token::take,
 };
@@ -86,7 +86,9 @@ impl SectionHeader {
     /// `*b"__data__\0\0\0\0\0\0\0\0\0\0\0"`
     pub const DATA_SECTION_HEADER_TAG: [u8; 19] = *b"__data__\0\0\0\0\0\0\0\0\0\0\0";
 
-    pub fn from_bytes<'a>(endian: Endianness) -> impl Parser<&'a [u8], Self, ContextError> {
+    pub fn from_bytes<'a>(
+        endian: Endianness,
+    ) -> impl Parser<&'a [u8], Self, ErrMode<ContextError>> {
         move |bytes: &mut &[u8]| {
             {
                 seq! {

--- a/serde_hkx/src/xml/de/mod.rs
+++ b/serde_hkx/src/xml/de/mod.rs
@@ -28,6 +28,7 @@ use parser::tag::{class_start_tag, start_tag};
 use winnow::Parser;
 use winnow::ascii::{dec_int, dec_uint};
 use winnow::combinator::opt;
+use winnow::error::{ContextError, ErrMode};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -181,7 +182,7 @@ impl<'de> XmlDeserializer<'de> {
     /// If an error occurs, it is converted to [`ReadableError`] and returned.
     fn parse_next<O>(
         &mut self,
-        mut parser: impl Parser<&'de str, O, winnow::error::ContextError>,
+        mut parser: impl Parser<&'de str, O, ErrMode<ContextError>>,
     ) -> Result<O> {
         let res = parser
             .parse_next(&mut self.input)
@@ -194,7 +195,7 @@ impl<'de> XmlDeserializer<'de> {
     /// If an error occurs, it is converted to [`ReadableError`] and returned.
     fn parse_peek<O>(
         &self,
-        mut parser: impl Parser<&'de str, O, winnow::error::ContextError>,
+        mut parser: impl Parser<&'de str, O, ErrMode<ContextError>>,
     ) -> Result<O> {
         let (_, res) = parser
             .parse_peek(self.input)

--- a/serde_hkx/src/xml/de/parser/mod.rs
+++ b/serde_hkx/src/xml/de/parser/mod.rs
@@ -4,7 +4,7 @@ pub mod type_kind;
 
 use winnow::ascii::multispace0;
 use winnow::combinator::{alt, delimited, fail, repeat};
-use winnow::error::{ContextError, StrContext, StrContextValue};
+use winnow::error::{ContextError, ErrMode, StrContext, StrContextValue};
 use winnow::token::take_until;
 use winnow::{ModalResult, Parser};
 
@@ -14,7 +14,7 @@ use winnow::{ModalResult, Parser};
 /// Has expected info.
 pub fn delimited_with_multispace0<'a>(
     s: &'static str,
-) -> impl Parser<&'a str, &'a str, ContextError> {
+) -> impl Parser<&'a str, &'a str, ErrMode<ContextError>> {
     delimited(multispace0, s, multispace0)
         .context(StrContext::Expected(StrContextValue::StringLiteral(s)))
 }
@@ -26,7 +26,7 @@ pub fn delimited_with_multispace0<'a>(
 /// Has expected info.
 pub fn delimited_comment_multispace0<'a>(
     s: &'static str,
-) -> impl Parser<&'a str, &'a str, ContextError> {
+) -> impl Parser<&'a str, &'a str, ErrMode<ContextError>> {
     delimited(comment_multispace0, s, multispace0)
         .context(StrContext::Expected(StrContextValue::StringLiteral(s)))
 }
@@ -38,7 +38,7 @@ pub fn delimited_comment_multispace0<'a>(
 /// Has expected info.
 pub fn delimited_multispace0_comment<'a>(
     s: &'static str,
-) -> impl Parser<&'a str, &'a str, ContextError> {
+) -> impl Parser<&'a str, &'a str, ErrMode<ContextError>> {
     delimited(multispace0, s, comment_multispace0)
         .context(StrContext::Expected(StrContextValue::StringLiteral(s)))
 }

--- a/serde_hkx/src/xml/de/parser/tag.rs
+++ b/serde_hkx/src/xml/de/parser/tag.rs
@@ -7,12 +7,15 @@ use super::{
 use havok_types::{Pointer, Signature};
 use winnow::ascii::{digit1, hex_digit1, oct_digit1};
 use winnow::combinator::{delimited, dispatch, fail, seq};
-use winnow::error::{ContextError, StrContext, StrContextValue, StrContextValue::*};
+use winnow::error::{
+    ContextError, ErrMode, StrContext,
+    StrContextValue::{self, *},
+};
 use winnow::token::{take, take_until};
 use winnow::{ModalResult, Parser};
 
 /// Parses the start tag `<tag>`
-pub fn start_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ContextError> {
+pub fn start_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ErrMode<ContextError>> {
     seq!(
         _: delimited_comment_multispace0("<"),
         _: delimited_with_multispace0(tag),
@@ -23,7 +26,7 @@ pub fn start_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ContextError
 }
 
 /// Parses the end tag `</tag>`
-pub fn end_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ContextError> {
+pub fn end_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ErrMode<ContextError>> {
     seq!(
         _: delimited_comment_multispace0("<"),
         _: delimited_with_multispace0("/"),
@@ -73,7 +76,7 @@ pub fn class_start_tag<'a>(input: &mut &'a str) -> ModalResult<(Pointer<'a>, &'a
 /// All arguments are used only for clarity of error reporting.
 pub fn field_start_open_tag<'a>(
     class_name: &'static str,
-) -> impl Parser<&'a str, (), ContextError> {
+) -> impl Parser<&'a str, (), ErrMode<ContextError>> {
     seq!(
         _: delimited_comment_multispace0("<"),
         _: delimited_with_multispace0("hkparam"),


### PR DESCRIPTION
- Updated `clap` from version 4.5.34 to 4.5.38 for CLI improvements.
- Updated `indexmap` from version 2.8.0 to 2.9.0 for better performance.
- Updated `proc-macro2` from version 1.0.94 to 1.0.95 for compatibility.
- Updated `syn` from version 2.0.100 to 2.0.101 for enhancements.
- Updated `tokio` from version 1.44.1 to 1.45.0 for async runtime improvements.
- Updated `winnow` from version 0.6.26 to 0.7.10, changing error handling to use `ErrMode`.
- Updated `prettyplease` from version 0.2.25 to 0.2.32 for code formatting.
- Updated `simd-json` from version 0.15.0 to 0.15.1 for performance improvements.
- Refactored error handling in various parser modules to utilize `ErrMode<ContextError>` for better error context management.

# New Features

# Changes and Fixes

# Refactors
